### PR TITLE
Implemented support for listening for key events from external HID devices (+misc minor bug fixes)

### DIFF
--- a/amx-modero-api.axi
+++ b/amx-modero-api.axi
@@ -247,6 +247,7 @@ char MODERO_COMMAND_QUERY_POPUP_SIZE[]                  = '?PUS'
 // Keyboard/keypad strings
 char MODERO_STRING_KEYBOARD[]   = 'KEYB-'
 char MODERO_STRING_KEYPAD[]     = 'KEYP'
+char MODERO_STRING_EXTERNAL_KEY = 'KEYE-'
 
 
 /*

--- a/amx-modero-api.axi
+++ b/amx-modero-api.axi
@@ -245,9 +245,9 @@ char MODERO_COMMAND_QUERY_POPUP_LOCATION[]              = '?PUL'
 char MODERO_COMMAND_QUERY_POPUP_SIZE[]                  = '?PUS'
 
 // Keyboard/keypad strings
-char MODERO_STRING_KEYBOARD[]   = 'KEYB-'
-char MODERO_STRING_KEYPAD[]     = 'KEYP'
-char MODERO_STRING_EXTERNAL_KEY = 'KEYE-'
+char MODERO_STRING_KEYBOARD[]     = 'KEYB-'
+char MODERO_STRING_KEYPAD[]       = 'KEYP'
+char MODERO_STRING_EXTERNAL_KEY[] = 'KEYE-'
 
 
 /*

--- a/amx-modero-api.axi
+++ b/amx-modero-api.axi
@@ -246,7 +246,7 @@ char MODERO_COMMAND_QUERY_POPUP_SIZE[]                  = '?PUS'
 
 // Keyboard/keypad strings
 char MODERO_STRING_KEYBOARD[]     = 'KEYB-'
-char MODERO_STRING_KEYPAD[]       = 'KEYP'
+char MODERO_STRING_KEYPAD[]       = 'KEYP-'
 char MODERO_STRING_EXTERNAL_KEY[] = 'KEYE-'
 
 

--- a/amx-modero-control.axi
+++ b/amx-modero-control.axi
@@ -114,7 +114,7 @@ define_function moderoSetPagePrevious (dev panel)
  */
 define_function moderoSetPageAnimated (dev panel, char pageName[], char pageFlipAnimation[], integer duration)
 {
-	sendCommand (panel, "MODERO_COMMAND_PAGE_FLIP_ANIMATED, pageName, pageFlipAnimation, itoa(duration)")
+	sendCommand (panel, "MODERO_COMMAND_PAGE_FLIP_ANIMATED, pageName, ',', pageFlipAnimation, ',', itoa(duration)")
 }
 
 

--- a/amx-modero-control.axi
+++ b/amx-modero-control.axi
@@ -1801,64 +1801,44 @@ define_function moderoSetStreamingAudioVideoMuteStatus (dev panel, char audioMut
  * Function:    moderoEnableStreamSession
  *
  * Arguments:   dev panel - touch panel
+ *              integer btnAdrCode - button address
+ *              integer btnState - button state
  *              char streamUrl[] - stream url
  *              integer streamPort - stream port
  *
  * Description: Start a streaming session.
  */
-define_function moderoEnableStreamSession (dev panel, char streamUrl[], integer streamPort)
+define_function moderoEnableStreamSession (dev panel, integer btnAdrCde, integer btnState, char streamUrl[], integer streamPort)
 {
-	sendCommand (panel, "MODERO_COMMAND_STREAMING_START_OR_STOP,'10,2,',streamUrl,':',itoa(streamPort)")
+	sendCommand (panel, "MODERO_COMMAND_STREAMING_START_OR_STOP, itoa(btnAdrCde), ',', itoa(btnState),',', streamUrl,':',itoa(streamPort)")
 }
 
 /*
  * Function:    moderoEnableStreamSessionCamera
  *
  * Arguments:   dev panel - touch panel
+ *              integer btnAdrCode - button address
+ *              integer btnState - button state
  *
  * Description: Start a streaming session from the built-in camera.
  */
-define_function moderoEnableStreamSessionCamera (dev panel)
+define_function moderoEnableStreamSessionCamera (dev panel, integer btnAdrCde, integer btnState)
 {
-	sendCommand (panel, "MODERO_COMMAND_STREAMING_START_OR_STOP,'10,2,',MODERO_STREAMING_CAMERA_URL")
+	sendCommand (panel, "MODERO_COMMAND_STREAMING_START_OR_STOP, itoa(btnAdrCde), ',', itoa(btnState), ',', MODERO_STREAMING_CAMERA_URL")
 }
 
 /*
  * Function:    moderoDisableStreamSession
  *
  * Arguments:   dev panel - touch panel
- *              char streamUrl[] - stream url
- *              integer streamPort - stream port
- *
- * Description: Stop a streaming session.
- */
-define_function moderoDisableStreamSession (dev panel, char streamAdr[], integer streamPort)
-{
-	sendCommand (panel, "MODERO_COMMAND_STREAMING_START_OR_STOP,'10,1,',streamAdr,':',itoa(streamPort)")
-}
-
-/*
- * Function:    moderoDisableStreamSessionCurrent
- *
- * Arguments:   dev panel - touch panel
+ *              integer btnAdrCode - button address
+ *              integer btnState - button state
  *
  * Description: Stop the current streaming session.
  */
-define_function moderoDisableStreamSessionCurrent (dev panel)
+define_function moderoDisableStreamSession (dev panel, integer btnAdrCde, integer btnState)
 {
-	sendCommand (panel, "MODERO_COMMAND_STREAMING_START_OR_STOP,'10,1,',MODERO_STREAMING_STOP")
-}
-
-/*
- * Function:    moderoDisableStreamSessionCamera
- *
- * Arguments:   dev panel - touch panel
- *
- * Description: Stop the current streaming session from the camera.
- */
-define_function moderoDisableStreamSessionCamera (dev panel)
-{
-	sendCommand (panel, "MODERO_COMMAND_STREAMING_START_OR_STOP,'10,1,',MODERO_STREAMING_CAMERA_URL")
+	sendCommand (panel, "MODERO_COMMAND_STREAMING_START_OR_STOP, itoa(btnAdrCde), ',', itoa(btnState), ',' ,MODERO_STREAMING_STOP")
 }
 
 /*

--- a/amx-modero-listener.axi
+++ b/amx-modero-listener.axi
@@ -641,7 +641,7 @@ data_event[dvPanelsUserTextInput]
 			{
 				remove_string (data.text, "MODERO_STRING_KEYPAD", 1)
 
-				if (data.text != MODERO_KEYPAD_ABORT)
+				if (data.text == MODERO_KEYPAD_ABORT)
 				{
 					#if_defined INCLUDE_MODERO_NOTIFY_KEYPAD_ABORT
 					moderoNotifyKeypadAbort (data.device)

--- a/amx-modero-listener.axi
+++ b/amx-modero-listener.axi
@@ -741,7 +741,7 @@ channel_event [dvPanelsFeedback, CHANNEL_CODE_WILDCARD]
  */
 
 #if_defined INCLUDE_MODERO_NOTIFY_LEVEL_CHANGE
-level_event [dvPanelsBargraphs, WILDCARD_LEVEL_CODE]
+level_event [dvPanelsBargraphs, LEVEL_CODE_WILDCARD]
 {
 	moderoNotifyLevelChange (level.input.device, level.input.level, level.value)
 }

--- a/amx-modero-listener.axi
+++ b/amx-modero-listener.axi
@@ -140,6 +140,15 @@ define_function moderoNotifyKeypadEntry (dev panel, char text[])
 */
 
 /*
+#define INCLUDE_MODERO_NOTIFY_EXTERNAL_KEY_EVENT
+define_function moderoNotifyExternalKeyEvent (dev panel, char key)
+{
+	// panel is the touch panel
+	// key is the character code associated with the event
+}
+*/
+
+/*
 #define INCLUDE_MODERO_NOTIFY_KEYPAD_ABORT
 define_function moderoNotifyKeypadAbort (dev panel)
 {
@@ -644,6 +653,15 @@ data_event[dvPanelsUserTextInput]
 					moderoNotifyKeypadEntry (data.device, data.text)
 					#end_if
 				}
+			}
+
+			active (find_string(data.text,"MODERO_STRING_EXTERNAL_KEY",1) == 1):
+			{
+				remove_string (data.text, "MODERO_STRING_EXTERNAL_KEY", 1)
+
+				#if_defined INCLUDE_MODERO_NOTIFY_EXTERNAL_KEY_EVENT
+				moderoNotifyExternalKeyEvent (data.device, data.text[1])
+				#end_if
 			}
 		}
 	}


### PR DESCRIPTION
Added listener for 'KEYE-' events. These are raised on current firmware when a panel has been set to passthrough an external HID device to the master.

note: to function HID passthrough must be enabled on a per-device basic with the ^KPS-5 command -- moderoEnableKeyboardPassthruMaster(..) in this library.
